### PR TITLE
fix highlighting for division without space

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -310,35 +310,10 @@
 			</array>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>/(?![\s=/*+{}?])</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.coffee</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(/)[igmy]{0,4}(?![a-zA-Z0-9])</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.coffee</string>
-				</dict>
-			</dict>
+			<key>match</key>
+			<string>/(?![\s=/*+{}?])(\\.|.)*?/[igmy]{0,4}(?![a-zA-Z0-9])</string>
 			<key>name</key>
 			<string>string.regexp.coffee</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>source.js.regexp</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
When writing a division without space (e.g. 4/3) the bundle thinks it is a regular expression and it highlights the rest of the code wrong.  Copied what jashenkas has in his for regular expressions, fixes it for me.