### PR TITLE
Updates regex for beginning of block comment

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -276,6 +276,7 @@
 		<dict>
 			<key>begin</key>
 			<string>(?&lt;!#)###(?!#)</string>
+			<string>(?&lt;!#)[\s]*###(?!#)</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Addresses #10 "Comment block is not working when the line has preceding whitespace"
Updates the regex to recognize the beginning of a block comment to recognize indented comments (spaced or tabbed).