### PR TITLE
Add keywords for `await` and `defer` (icedcoffeescript)

### DIFF
--- a/Syntaxes/CoffeeScript.tmLanguage
+++ b/Syntaxes/CoffeeScript.tmLanguage
@@ -399,10 +399,12 @@
 				\b
 				(?&lt;![\.\$])
 				(
-					break
+				    await
+				  | break
 				  | by
 				  | catch
 				  | continue
+				  | defer
 				  | else
 				  | finally
 				  | for


### PR DESCRIPTION
Not sure if there is a way to restrict those to just iced coffeescript, but at the very least this does what's needed to highlight those keywords nicely.